### PR TITLE
feat: P4ADEV-2796 Created mapper from debt position event

### DIFF
--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapper.java
@@ -5,22 +5,11 @@ import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.Objects;
-
 @Slf4j
 @Service
 public class DebtPositionEventDTO2DebtPositionRegistryMapper {
 
   public DebtPositionRegistry map(DebtPositionEventDTO dto) {
-    Objects.requireNonNull(dto.getEventId(), "eventId cannot be null");
-    Objects.requireNonNull(dto.getEventType(), "eventType cannot be null");
-    Objects.requireNonNull(dto.getTraceId(), "traceId cannot be null");
-    Objects.requireNonNull(dto.getEventDateTime(), "eventDateTime cannot be null");
-    Objects.requireNonNull(dto.getPayload(), "payload cannot be null");
-    Objects.requireNonNull(dto.getPayload().getDebtPositionId(), "payload.debtPositionId cannot be null");
-    Objects.requireNonNull(dto.getPayload().getUpdateOperatorExternalId(), "payload.updateOperatorExternalId cannot be null");
-    Objects.requireNonNull(dto.getPayload().getOrganizationId(), "payload.organizationId cannot be null");
-
     return DebtPositionRegistry.builder()
       .eventId(dto.getEventId())
       .eventType(dto.getEventType())

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapper.java
@@ -1,0 +1,36 @@
+package it.gov.pagopa.pu.registry.mapper.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+public class DebtPositionEventDTO2DebtPositionRegistryMapper {
+
+  public DebtPositionRegistry map(DebtPositionEventDTO dto) {
+    Objects.requireNonNull(dto.getEventId(), "eventId cannot be null");
+    Objects.requireNonNull(dto.getEventType(), "eventType cannot be null");
+    Objects.requireNonNull(dto.getTraceId(), "traceId cannot be null");
+    Objects.requireNonNull(dto.getEventDateTime(), "eventDateTime cannot be null");
+    Objects.requireNonNull(dto.getPayload(), "payload cannot be null");
+    Objects.requireNonNull(dto.getPayload().getDebtPositionId(), "payload.debtPositionId cannot be null");
+    Objects.requireNonNull(dto.getPayload().getUpdateOperatorExternalId(), "payload.updateOperatorExternalId cannot be null");
+    Objects.requireNonNull(dto.getPayload().getOrganizationId(), "payload.organizationId cannot be null");
+
+    return DebtPositionRegistry.builder()
+      .eventId(dto.getEventId())
+      .eventType(dto.getEventType())
+      .traceId(dto.getTraceId())
+      .eventDateTime(dto.getEventDateTime())
+      .eventDescription(dto.getEventDescription())
+      .operatorExternalUserId(dto.getPayload().getUpdateOperatorExternalId())
+      .debtPositionId(dto.getPayload().getDebtPositionId())
+      .organizationId(dto.getPayload().getOrganizationId())
+      .build();
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapper.java
@@ -1,0 +1,64 @@
+package it.gov.pagopa.pu.registry.mapper.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
+import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import it.gov.pagopa.pu.workflowhub.dto.generated.InstallmentDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentOptionDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+public class DebtPositionEventDTO2InstallmentRegistryMapper {
+
+  public List<InstallmentRegistry> map(DebtPositionEventDTO dto) {
+    Objects.requireNonNull(dto.getEventId(), "eventId cannot be null");
+    Objects.requireNonNull(dto.getEventType(), "eventType cannot be null");
+    Objects.requireNonNull(dto.getTraceId(), "traceId cannot be null");
+    Objects.requireNonNull(dto.getEventDateTime(), "eventDateTime cannot be null");
+    Objects.requireNonNull(dto.getPayload(), "payload cannot be null");
+    Objects.requireNonNull(dto.getPayload().getDebtPositionId(), "payload.debtPositionId cannot be null");
+    Objects.requireNonNull(dto.getPayload().getUpdateOperatorExternalId(), "payload.updateOperatorExternalId cannot be null");
+    Objects.requireNonNull(dto.getPayload().getOrganizationId(), "payload.organizationId cannot be null");
+    Objects.requireNonNull(dto.getPayload().getPaymentOptions(), "payload.paymentOptions cannot be null");
+
+    List<InstallmentRegistry> installmentRegistries = new ArrayList<>();
+
+    for (PaymentOptionDTO paymentOptionDTO : dto.getPayload().getPaymentOptions()) {
+      if (paymentOptionDTO.getInstallments() == null) continue;
+
+      for (InstallmentDTO installmentDTO : paymentOptionDTO.getInstallments()) {
+        if (installmentDTO.getNav() == null) {
+          log.warn("InstallmentDTO nav is null, skipping this installment");
+          continue;
+        }
+
+        if (installmentDTO.getUpdateOperatorExternalId() == null) {
+          log.warn("InstallmentDTO updateOperatorExternalId is null, skipping this installment");
+          continue;
+        }
+
+        InstallmentRegistry installmentRegistry = InstallmentRegistry.builder()
+          .eventId(dto.getEventId() + "." + installmentDTO.getNav())
+          .eventType(dto.getEventType())
+          .traceId(dto.getTraceId())
+          .eventDateTime(dto.getEventDateTime())
+          .eventDescription(dto.getEventDescription())
+          .operatorExternalUserId(installmentDTO.getUpdateOperatorExternalId())
+          .debtPositionId(dto.getPayload().getDebtPositionId())
+          .organizationId(dto.getPayload().getOrganizationId())
+          .nav(installmentDTO.getNav())
+          .build();
+
+        installmentRegistries.add(installmentRegistry);
+      }
+    }
+
+    return installmentRegistries;
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapper.java
@@ -10,55 +10,30 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 public class DebtPositionEventDTO2InstallmentRegistryMapper {
 
   public List<InstallmentRegistry> map(DebtPositionEventDTO dto) {
-    Objects.requireNonNull(dto.getEventId(), "eventId cannot be null");
-    Objects.requireNonNull(dto.getEventType(), "eventType cannot be null");
-    Objects.requireNonNull(dto.getTraceId(), "traceId cannot be null");
-    Objects.requireNonNull(dto.getEventDateTime(), "eventDateTime cannot be null");
-    Objects.requireNonNull(dto.getPayload(), "payload cannot be null");
-    Objects.requireNonNull(dto.getPayload().getDebtPositionId(), "payload.debtPositionId cannot be null");
-    Objects.requireNonNull(dto.getPayload().getUpdateOperatorExternalId(), "payload.updateOperatorExternalId cannot be null");
-    Objects.requireNonNull(dto.getPayload().getOrganizationId(), "payload.organizationId cannot be null");
-    Objects.requireNonNull(dto.getPayload().getPaymentOptions(), "payload.paymentOptions cannot be null");
+    if (dto.getPayload().getPaymentOptions() == null) return List.of();
 
-    List<InstallmentRegistry> installmentRegistries = new ArrayList<>();
-
-    for (PaymentOptionDTO paymentOptionDTO : dto.getPayload().getPaymentOptions()) {
-      if (paymentOptionDTO.getInstallments() == null) continue;
-
-      for (InstallmentDTO installmentDTO : paymentOptionDTO.getInstallments()) {
-        if (installmentDTO.getNav() == null) {
-          log.warn("InstallmentDTO nav is null, skipping this installment");
-          continue;
-        }
-
-        if (installmentDTO.getUpdateOperatorExternalId() == null) {
-          log.warn("InstallmentDTO updateOperatorExternalId is null, skipping this installment");
-          continue;
-        }
-
-        InstallmentRegistry installmentRegistry = InstallmentRegistry.builder()
-          .eventId(dto.getEventId() + "." + installmentDTO.getNav())
-          .eventType(dto.getEventType())
-          .traceId(dto.getTraceId())
-          .eventDateTime(dto.getEventDateTime())
-          .eventDescription(dto.getEventDescription())
-          .operatorExternalUserId(installmentDTO.getUpdateOperatorExternalId())
-          .debtPositionId(dto.getPayload().getDebtPositionId())
-          .organizationId(dto.getPayload().getOrganizationId())
-          .nav(installmentDTO.getNav())
-          .build();
-
-        installmentRegistries.add(installmentRegistry);
-      }
-    }
-
-    return installmentRegistries;
+    return dto.getPayload().getPaymentOptions().stream()
+      .filter(paymentOptionDTO -> paymentOptionDTO.getInstallments() != null)
+      .flatMap(paymentOptionDTO -> paymentOptionDTO.getInstallments().stream())
+      .map(installmentDTO -> InstallmentRegistry.builder()
+        .eventId(dto.getEventId() + "." + installmentDTO.getNav())
+        .eventType(dto.getEventType())
+        .traceId(dto.getTraceId())
+        .eventDateTime(dto.getEventDateTime())
+        .eventDescription(dto.getEventDescription())
+        .operatorExternalUserId(installmentDTO.getUpdateOperatorExternalId())
+        .debtPositionId(dto.getPayload().getDebtPositionId())
+        .organizationId(dto.getPayload().getOrganizationId())
+        .nav(installmentDTO.getNav())
+        .build())
+      .collect(Collectors.toList());
   }
 
 }

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapperTest.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.pu.registry.mapper.debtposition;
 
 import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
 import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import it.gov.pagopa.pu.registry.utils.TestUtils;
 import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
 import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,7 @@ public class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
   void map_shouldMapCorrectly_whenValidInput() {
     DebtPositionEventDTO dto = createValidDto();
     DebtPositionRegistry result = mapper.map(dto);
+    TestUtils.checkNotNullFields(result);
 
     assertEquals(dto.getEventId(), result.getEventId());
     assertEquals(dto.getEventType(), result.getEventType());
@@ -34,51 +36,6 @@ public class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
     assertEquals(dto.getPayload().getDebtPositionId(), result.getDebtPositionId());
     assertEquals(dto.getPayload().getUpdateOperatorExternalId(), result.getOperatorExternalUserId());
     assertEquals(dto.getPayload().getOrganizationId(), result.getOrganizationId());
-  }
-
-  @Test
-  void map_shouldFailMapping_whenNullValues() {
-    DebtPositionEventDTO dto = createValidDto();
-
-    // validate eventId
-    dto.setEventId(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(dto));
-
-    // validate eventType
-    dto.setEventId("eventId1");
-    dto.setEventType(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(dto));
-
-    // validate traceId
-    dto.setTraceId(null);
-    dto.setEventType(PaymentEventType.DP_CREATED);
-    assertThrows(NullPointerException.class, () -> mapper.map(dto));
-
-    // validate event datetime
-    dto.setEventDateTime(null);
-    dto.setTraceId("traceId2");
-    assertThrows(NullPointerException.class, () -> mapper.map(dto));
-
-    // validate payload
-    dto.setEventDateTime(OffsetDateTime.now());
-    DebtPositionDTO payload = dto.getPayload();
-    dto.setPayload(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(dto));
-
-    // validate payload debt position id
-    dto.setPayload(payload);
-    dto.getPayload().setDebtPositionId(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(dto));
-
-    // validate payload operator external id
-    dto.getPayload().setDebtPositionId(payload.getDebtPositionId());
-    dto.getPayload().setUpdateOperatorExternalId(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(dto));
-
-    // validate payload organization id
-    dto.getPayload().setUpdateOperatorExternalId(payload.getUpdateOperatorExternalId());
-    dto.getPayload().setOrganizationId(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(dto));
   }
 
   private DebtPositionEventDTO createValidDto() {

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapperTest.java
@@ -1,0 +1,101 @@
+package it.gov.pagopa.pu.registry.mapper.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
+
+  private DebtPositionEventDTO2DebtPositionRegistryMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new DebtPositionEventDTO2DebtPositionRegistryMapper();
+  }
+
+  @Test
+  void map_shouldMapCorrectly_whenValidInput() {
+    DebtPositionEventDTO dto = createValidDto();
+    DebtPositionRegistry result = mapper.map(dto);
+
+    assertEquals(dto.getEventId(), result.getEventId());
+    assertEquals(dto.getEventType(), result.getEventType());
+    assertEquals(dto.getTraceId(), result.getTraceId());
+    assertEquals(dto.getEventDateTime(), result.getEventDateTime());
+    assertEquals(dto.getEventDescription(), result.getEventDescription());
+    assertEquals(dto.getPayload().getDebtPositionId(), result.getDebtPositionId());
+    assertEquals(dto.getPayload().getUpdateOperatorExternalId(), result.getOperatorExternalUserId());
+    assertEquals(dto.getPayload().getOrganizationId(), result.getOrganizationId());
+  }
+
+  @Test
+  void map_shouldFailMapping_whenNullValues() {
+    DebtPositionEventDTO dto = createValidDto();
+
+    // validate eventId
+    dto.setEventId(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(dto));
+
+    // validate eventType
+    dto.setEventId("eventId1");
+    dto.setEventType(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(dto));
+
+    // validate traceId
+    dto.setTraceId(null);
+    dto.setEventType(PaymentEventType.DP_CREATED);
+    assertThrows(NullPointerException.class, () -> mapper.map(dto));
+
+    // validate event datetime
+    dto.setEventDateTime(null);
+    dto.setTraceId("traceId2");
+    assertThrows(NullPointerException.class, () -> mapper.map(dto));
+
+    // validate payload
+    dto.setEventDateTime(OffsetDateTime.now());
+    DebtPositionDTO payload = dto.getPayload();
+    dto.setPayload(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(dto));
+
+    // validate payload debt position id
+    dto.setPayload(payload);
+    dto.getPayload().setDebtPositionId(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(dto));
+
+    // validate payload operator external id
+    dto.getPayload().setDebtPositionId(payload.getDebtPositionId());
+    dto.getPayload().setUpdateOperatorExternalId(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(dto));
+
+    // validate payload organization id
+    dto.getPayload().setUpdateOperatorExternalId(payload.getUpdateOperatorExternalId());
+    dto.getPayload().setOrganizationId(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(dto));
+  }
+
+  private DebtPositionEventDTO createValidDto() {
+    DebtPositionDTO payload = DebtPositionDTO.builder()
+      .debtPositionId(123L)
+      .updateOperatorExternalId("externalOperatorId456")
+      .organizationId(789L)
+      .build();
+
+    return DebtPositionEventDTO.builder()
+      .eventId("eventId1")
+      .eventType(PaymentEventType.DP_CREATED)
+      .traceId("traceId2")
+      .eventDateTime(OffsetDateTime.now())
+      .eventDescription("Some event description")
+      .payload(payload)
+      .build();
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapperTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import java.time.OffsetDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
 

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
@@ -1,0 +1,133 @@
+package it.gov.pagopa.pu.registry.mapper.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
+import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.InstallmentDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentOptionDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
+
+  private DebtPositionEventDTO2InstallmentRegistryMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new DebtPositionEventDTO2InstallmentRegistryMapper();
+  }
+
+  @Test
+  void map_shouldMapCorrectly_whenValidInput() {
+    DebtPositionEventDTO dto = createValidDto();
+    List<InstallmentRegistry> result = mapper.map(dto);
+
+    assertEquals(2, result.size());
+    assertNotNull(dto.getPayload().getPaymentOptions());
+    assertNotNull(dto.getPayload().getPaymentOptions().getFirst().getInstallments());
+
+    InstallmentDTO firstInstallment = dto.getPayload().getPaymentOptions().getFirst().getInstallments().getFirst();
+
+    assertEquals(dto.getEventId() + "." + firstInstallment.getNav(), result.getFirst().getEventId());
+    assertEquals(dto.getEventType(), result.getFirst().getEventType());
+    assertEquals(dto.getTraceId(), result.getFirst().getTraceId());
+    assertEquals(dto.getEventDateTime(), result.getFirst().getEventDateTime());
+    assertEquals(dto.getEventDescription(), result.getFirst().getEventDescription());
+    assertEquals(dto.getPayload().getDebtPositionId(), result.getFirst().getDebtPositionId());
+    assertEquals(firstInstallment.getUpdateOperatorExternalId(), result.getFirst().getOperatorExternalUserId());
+    assertEquals(dto.getPayload().getOrganizationId(), result.getFirst().getOrganizationId());
+  }
+
+  @Test
+  void map_shouldFailMapping_whenNullValues() {
+    final var ref = new Object() {
+      DebtPositionEventDTO dto = createValidDto();
+    };
+
+    // validate eventId
+    ref.dto.setEventId(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
+
+    // validate eventType
+    ref.dto = createValidDto();
+    ref.dto.setEventType(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
+
+    // validate traceId
+    ref.dto = createValidDto();
+    ref.dto.setTraceId(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
+
+    // validate event datetime
+    ref.dto = createValidDto();
+    ref.dto.setEventDateTime(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
+
+    // validate payload
+    ref.dto = createValidDto();
+    ref.dto.setPayload(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
+
+    // validate payload debt position id
+    ref.dto = createValidDto();
+    ref.dto.getPayload().setDebtPositionId(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
+
+    // validate payload installment operator external id
+    ref.dto = createValidDto();
+    ref.dto.getPayload().getPaymentOptions().getFirst().getInstallments().getFirst().setUpdateOperatorExternalId(null);
+    assertEquals(1, mapper.map(ref.dto).size());
+
+    // validate payload installment nav
+    ref.dto = createValidDto();
+    ref.dto.getPayload().getPaymentOptions().getFirst().getInstallments().getFirst().setNav(null);
+    assertEquals(1, mapper.map(ref.dto).size());
+
+    // validate payload organization id
+    ref.dto = createValidDto();
+    ref.dto.getPayload().setOrganizationId(null);
+    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
+  }
+
+  private DebtPositionEventDTO createValidDto() {
+    List<InstallmentDTO> installments = List.of(
+      InstallmentDTO.builder()
+        .nav("nav1")
+        .updateOperatorExternalId("operatorExternalId123")
+        .build(),
+      InstallmentDTO.builder()
+        .nav("nav2")
+        .updateOperatorExternalId("operatorExternalId456")
+        .build()
+    );
+
+    List<PaymentOptionDTO> paymentOptions = List.of(
+      PaymentOptionDTO.builder()
+        .installments(installments)
+        .build()
+    );
+
+    DebtPositionDTO payload = DebtPositionDTO.builder()
+      .debtPositionId(123L)
+      .updateOperatorExternalId("externalOperatorId456")
+      .organizationId(789L)
+      .paymentOptions(paymentOptions)
+      .build();
+
+    return DebtPositionEventDTO.builder()
+      .eventId("eventId1")
+      .eventType(PaymentEventType.DP_CREATED)
+      .traceId("traceId2")
+      .eventDateTime(OffsetDateTime.now())
+      .eventDescription("Some event description")
+      .payload(payload)
+      .build();
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
@@ -41,8 +41,8 @@ public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
     assertEquals(dto.getPayload().getDebtPositionId(), result.getFirst().getDebtPositionId());
     assertEquals(dto.getPayload().getOrganizationId(), result.getFirst().getOrganizationId());
 
-    InstallmentDTO firstInstallmentDTO = dto.getPayload().getPaymentOptions().get(0).getInstallments().get(0);
-    InstallmentDTO secondInstallmentDTO = dto.getPayload().getPaymentOptions().get(0).getInstallments().get(1);
+    InstallmentDTO firstInstallmentDTO = dto.getPayload().getPaymentOptions().getFirst().getInstallments().get(0);
+    InstallmentDTO secondInstallmentDTO = dto.getPayload().getPaymentOptions().getFirst().getInstallments().get(1);
     TestUtils.checkNotNullFields(result.get(0));
     TestUtils.checkNotNullFields(result.get(1));
     assertEquals(dto.getEventId() + "." + firstInstallmentDTO.getNav(), result.get(0).getEventId());

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
 

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
@@ -41,17 +41,17 @@ public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
     assertEquals(dto.getPayload().getDebtPositionId(), result.getFirst().getDebtPositionId());
     assertEquals(dto.getPayload().getOrganizationId(), result.getFirst().getOrganizationId());
 
-    IntStream.range(0, dto.getPayload().getPaymentOptions().size()).forEach(i -> {
-      PaymentOptionDTO paymentOptionDTO = dto.getPayload().getPaymentOptions().get(i);
-      IntStream.range(0, paymentOptionDTO.getInstallments().size()).forEach(j -> {
-        InstallmentDTO installmentDTO = paymentOptionDTO.getInstallments().get(j);
-        InstallmentRegistry installmentRegistry = result.get(i + j);
-        TestUtils.checkNotNullFields(installmentRegistry);
-        assertEquals(dto.getEventId() + "." + installmentDTO.getNav(), installmentRegistry.getEventId());
-        assertEquals(installmentDTO.getNav(), installmentRegistry.getNav());
-        assertEquals(installmentDTO.getUpdateOperatorExternalId(), installmentRegistry.getOperatorExternalUserId());
-      });
-    });
+    InstallmentDTO firstInstallmentDTO = dto.getPayload().getPaymentOptions().get(0).getInstallments().get(0);
+    InstallmentDTO secondInstallmentDTO = dto.getPayload().getPaymentOptions().get(0).getInstallments().get(1);
+    TestUtils.checkNotNullFields(result.get(0));
+    TestUtils.checkNotNullFields(result.get(1));
+    assertEquals(dto.getEventId() + "." + firstInstallmentDTO.getNav(), result.get(0).getEventId());
+    assertEquals(firstInstallmentDTO.getNav(), result.get(0).getNav());
+    assertEquals(firstInstallmentDTO.getUpdateOperatorExternalId(), result.get(0).getOperatorExternalUserId());
+
+    assertEquals(dto.getEventId() + "." + secondInstallmentDTO.getNav(), result.get(1).getEventId());
+    assertEquals(secondInstallmentDTO.getNav(), result.get(1).getNav());
+    assertEquals(secondInstallmentDTO.getUpdateOperatorExternalId(), result.get(1).getOperatorExternalUserId());
   }
 
   private DebtPositionEventDTO createValidDto() {

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.pu.registry.mapper.installment;
 
 import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
 import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import it.gov.pagopa.pu.registry.utils.TestUtils;
 import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
 import it.gov.pagopa.pu.workflowhub.dto.generated.InstallmentDTO;
 import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
@@ -27,6 +28,7 @@ public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
   void map_shouldMapCorrectly_whenValidInput() {
     DebtPositionEventDTO dto = createValidDto();
     List<InstallmentRegistry> result = mapper.map(dto);
+    result.forEach(TestUtils::checkNotNullFields);
 
     assertEquals(2, result.size());
     assertNotNull(dto.getPayload().getPaymentOptions());
@@ -42,57 +44,6 @@ public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
     assertEquals(dto.getPayload().getDebtPositionId(), result.getFirst().getDebtPositionId());
     assertEquals(firstInstallment.getUpdateOperatorExternalId(), result.getFirst().getOperatorExternalUserId());
     assertEquals(dto.getPayload().getOrganizationId(), result.getFirst().getOrganizationId());
-  }
-
-  @Test
-  void map_shouldFailMapping_whenNullValues() {
-    final var ref = new Object() {
-      DebtPositionEventDTO dto = createValidDto();
-    };
-
-    // validate eventId
-    ref.dto.setEventId(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
-
-    // validate eventType
-    ref.dto = createValidDto();
-    ref.dto.setEventType(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
-
-    // validate traceId
-    ref.dto = createValidDto();
-    ref.dto.setTraceId(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
-
-    // validate event datetime
-    ref.dto = createValidDto();
-    ref.dto.setEventDateTime(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
-
-    // validate payload
-    ref.dto = createValidDto();
-    ref.dto.setPayload(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
-
-    // validate payload debt position id
-    ref.dto = createValidDto();
-    ref.dto.getPayload().setDebtPositionId(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
-
-    // validate payload installment operator external id
-    ref.dto = createValidDto();
-    ref.dto.getPayload().getPaymentOptions().getFirst().getInstallments().getFirst().setUpdateOperatorExternalId(null);
-    assertEquals(1, mapper.map(ref.dto).size());
-
-    // validate payload installment nav
-    ref.dto = createValidDto();
-    ref.dto.getPayload().getPaymentOptions().getFirst().getInstallments().getFirst().setNav(null);
-    assertEquals(1, mapper.map(ref.dto).size());
-
-    // validate payload organization id
-    ref.dto = createValidDto();
-    ref.dto.getPayload().setOrganizationId(null);
-    assertThrows(NullPointerException.class, () -> mapper.map(ref.dto));
   }
 
   private DebtPositionEventDTO createValidDto() {

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,17 +34,24 @@ public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
     assertEquals(2, result.size());
     assertNotNull(dto.getPayload().getPaymentOptions());
     assertNotNull(dto.getPayload().getPaymentOptions().getFirst().getInstallments());
-
-    InstallmentDTO firstInstallment = dto.getPayload().getPaymentOptions().getFirst().getInstallments().getFirst();
-
-    assertEquals(dto.getEventId() + "." + firstInstallment.getNav(), result.getFirst().getEventId());
     assertEquals(dto.getEventType(), result.getFirst().getEventType());
     assertEquals(dto.getTraceId(), result.getFirst().getTraceId());
     assertEquals(dto.getEventDateTime(), result.getFirst().getEventDateTime());
     assertEquals(dto.getEventDescription(), result.getFirst().getEventDescription());
     assertEquals(dto.getPayload().getDebtPositionId(), result.getFirst().getDebtPositionId());
-    assertEquals(firstInstallment.getUpdateOperatorExternalId(), result.getFirst().getOperatorExternalUserId());
     assertEquals(dto.getPayload().getOrganizationId(), result.getFirst().getOrganizationId());
+
+    IntStream.range(0, dto.getPayload().getPaymentOptions().size()).forEach(i -> {
+      PaymentOptionDTO paymentOptionDTO = dto.getPayload().getPaymentOptions().get(i);
+      IntStream.range(0, paymentOptionDTO.getInstallments().size()).forEach(j -> {
+        InstallmentDTO installmentDTO = paymentOptionDTO.getInstallments().get(j);
+        InstallmentRegistry installmentRegistry = result.get(i + j);
+        TestUtils.checkNotNullFields(installmentRegistry);
+        assertEquals(dto.getEventId() + "." + installmentDTO.getNav(), installmentRegistry.getEventId());
+        assertEquals(installmentDTO.getNav(), installmentRegistry.getNav());
+        assertEquals(installmentDTO.getUpdateOperatorExternalId(), installmentRegistry.getOperatorExternalUserId());
+      });
+    });
   }
 
   private DebtPositionEventDTO createValidDto() {


### PR DESCRIPTION
#### Description
Created two mapper services that take as input a `DebtPositionEvent` and maps it to a `DebtPositionRegistry` or multiple `InstallmentRegistry` for tracing.

#### List of Changes
* Created the mapper `DebtPositionEventDTO2DebtPositionRegistryMapper` for `DebtPositionEventDTO` conversion into `DebtPositionRegistry` entity with relative unit tests
* Created the mapper `DebtPositionEventDTO2InstallmentRegistryMapper` for `DebtPositionEventDTO` conversion into `InstallmentRegistry` entity with relative unit tests

#### Motivation and Context
To handle the history and tracing of all the debt position events.

#### How Has This Been Tested?
- Pre-Deploy Test
  - [x] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load