### PR TITLE
feat: P4ADEV_2804 Implemented custom queries for installment and debt position

### DIFF
--- a/openapi/generated.openapi.json
+++ b/openapi/generated.openapi.json
@@ -98,6 +98,35 @@
         }
       }
     },
+    "/crud/debt-position-registries/search/findAllByDebtPositionId" : {
+      "get" : {
+        "tags" : [ "debt-position-registry-search-controller" ],
+        "operationId" : "crud-debt-position-registries-findAllByDebtPositionId",
+        "parameters" : [ {
+          "name" : "debtPositionId",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionModelDebtPositionRegistry"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        }
+      }
+    },
     "/crud/debt-position-registries/{id}" : {
       "get" : {
         "tags" : [ "debt-position-registry-entity-controller" ],
@@ -319,6 +348,70 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/crud/installment-registries/search/findAllByDebtPositionId" : {
+      "get" : {
+        "tags" : [ "installment-registry-search-controller" ],
+        "operationId" : "crud-installment-registries-findAllByDebtPositionId",
+        "parameters" : [ {
+          "name" : "debtPositionId",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionModelInstallmentRegistry"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        }
+      }
+    },
+    "/crud/installment-registries/search/findAllByDebtPositionIdAndNav" : {
+      "get" : {
+        "tags" : [ "installment-registry-search-controller" ],
+        "operationId" : "crud-installment-registries-findAllByDebtPositionIdAndNav",
+        "parameters" : [ {
+          "name" : "debtPositionId",
+          "in" : "query",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "nav",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/hal+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionModelInstallmentRegistry"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
           }
         }
       }
@@ -703,6 +796,82 @@
           }
         }
       },
+      "DebtPositionRegistry" : {
+        "type" : "object",
+        "properties" : {
+          "eventId" : {
+            "type" : "string"
+          },
+          "eventType" : {
+            "$ref" : "#/components/schemas/PaymentEventType"
+          },
+          "eventDateTime" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "eventDescription" : {
+            "type" : "string"
+          },
+          "operatorExternalUserId" : {
+            "type" : "string"
+          },
+          "traceId" : {
+            "type" : "string"
+          },
+          "debtPositionId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "organizationId" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "_links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
+      "PagedModelDebtPositionRegistry" : {
+        "type" : "object",
+        "properties" : {
+          "_embedded" : {
+            "type" : "object",
+            "properties" : {
+              "debtPositionRegistries" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/DebtPositionRegistry"
+                }
+              }
+            }
+          },
+          "_links" : {
+            "$ref" : "#/components/schemas/Links"
+          },
+          "page" : {
+            "$ref" : "#/components/schemas/PageMetadata"
+          }
+        }
+      },
+      "CollectionModelDebtPositionRegistry" : {
+        "type" : "object",
+        "properties" : {
+          "_embedded" : {
+            "type" : "object",
+            "properties" : {
+              "debtPositionRegistries" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/components/schemas/DebtPositionRegistry"
+                }
+              }
+            }
+          },
+          "_links" : {
+            "$ref" : "#/components/schemas/Links"
+          }
+        }
+      },
       "InstallmentRegistry" : {
         "type" : "object",
         "properties" : {
@@ -763,60 +932,22 @@
           }
         }
       },
-      "DebtPositionRegistry" : {
-        "type" : "object",
-        "properties" : {
-          "eventId" : {
-            "type" : "string"
-          },
-          "eventType" : {
-            "$ref" : "#/components/schemas/PaymentEventType"
-          },
-          "eventDateTime" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
-          "eventDescription" : {
-            "type" : "string"
-          },
-          "operatorExternalUserId" : {
-            "type" : "string"
-          },
-          "traceId" : {
-            "type" : "string"
-          },
-          "debtPositionId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "organizationId" : {
-            "type" : "integer",
-            "format" : "int64"
-          },
-          "_links" : {
-            "$ref" : "#/components/schemas/Links"
-          }
-        }
-      },
-      "PagedModelDebtPositionRegistry" : {
+      "CollectionModelInstallmentRegistry" : {
         "type" : "object",
         "properties" : {
           "_embedded" : {
             "type" : "object",
             "properties" : {
-              "debtPositionRegistries" : {
+              "installmentRegistries" : {
                 "type" : "array",
                 "items" : {
-                  "$ref" : "#/components/schemas/DebtPositionRegistry"
+                  "$ref" : "#/components/schemas/InstallmentRegistry"
                 }
               }
             }
           },
           "_links" : {
             "$ref" : "#/components/schemas/Links"
-          },
-          "page" : {
-            "$ref" : "#/components/schemas/PageMetadata"
           }
         }
       },

--- a/src/main/java/it/gov/pagopa/pu/registry/repository/DebtPositionRegistryRepository.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/repository/DebtPositionRegistryRepository.java
@@ -4,6 +4,9 @@ import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+import java.util.List;
+
 @RepositoryRestResource(path = "debt-position-registries")
 public interface DebtPositionRegistryRepository extends MongoRepository<DebtPositionRegistry, String> {
+  List<DebtPositionRegistry> findAllByDebtPositionId(Long debtPositionId);
 }

--- a/src/main/java/it/gov/pagopa/pu/registry/repository/InstallmentRegistryRepository.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/repository/InstallmentRegistryRepository.java
@@ -4,6 +4,10 @@ import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+import java.util.List;
+
 @RepositoryRestResource(path = "installment-registries")
 public interface InstallmentRegistryRepository extends MongoRepository<InstallmentRegistry, String> {
+  List<InstallmentRegistry> findAllByDebtPositionIdAndNav(Long debtPositionId, String nav);
+  List<InstallmentRegistry> findAllByDebtPositionId(Long debtPositionId);
 }


### PR DESCRIPTION
#### Description
Implemented in the repository three [3] custom queries:
* find all debt position registries by debt position id
* find all installment registries by debt position id and nav
* find all installment registries by debt position id

#### List of Changes
* Created the method `findAllByDebtPositionId` in `DebtPositionRegistryRepository`
* Created the method `findAllByDebtPositionIdAndNav ` in `InstallmentRegistryRepository`
* Created the method `findAllByDebtPositionId ` in `InstallmentRegistryRepository`

#### Motivation and Context
In order to expose to external applications a customer search for the registries.

#### How Has This Been Tested?
- Pre-Deploy Test
  - [ ] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load