### PR TITLE
feat: P4ADEV-2797 implemented IO events mappers

### DIFF
--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionIoEventDTO2DebtPositionRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionIoEventDTO2DebtPositionRegistryMapper.java
@@ -1,0 +1,24 @@
+package it.gov.pagopa.pu.registry.mapper.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionIoEventDTO;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class DebtPositionIoEventDTO2DebtPositionRegistryMapper {
+
+  public DebtPositionRegistry map(DebtPositionIoEventDTO dto) {
+    return DebtPositionRegistry.builder()
+      .eventId(dto.getEventId())
+      .eventType(dto.getEventType())
+      .traceId(dto.getTraceId())
+      .eventDateTime(dto.getEventDateTime())
+      .eventDescription(dto.getEventDescription())
+      .debtPositionId(dto.getPayload().getDebtPositionId())
+      .organizationId(dto.getPayload().getOrganizationId())
+      .build();
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapper.java
@@ -2,17 +2,10 @@ package it.gov.pagopa.pu.registry.mapper.installment;
 
 import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
 import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
-import it.gov.pagopa.pu.workflowhub.dto.generated.InstallmentDTO;
-import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentOptionDTO;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 public class DebtPositionEventDTO2InstallmentRegistryMapper {
 
@@ -33,7 +26,7 @@ public class DebtPositionEventDTO2InstallmentRegistryMapper {
         .organizationId(dto.getPayload().getOrganizationId())
         .nav(installmentDTO.getNav())
         .build())
-      .collect(Collectors.toList());
+      .toList();
   }
 
 }

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapper.java
@@ -4,9 +4,9 @@ import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionIoEventDTO;
 import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -16,7 +16,7 @@ public class DebtPositionIoEventDTO2InstallmentRegistryMapper {
     if (dto.getPayload().getMessages() == null) return List.of();
 
     return dto.getPayload().getMessages().stream()
-      .filter(ioMessageDTO -> ioMessageDTO.getNav() != null && !ioMessageDTO.getNav().isEmpty())
+      .filter(ioMessageDTO -> StringUtils.hasText(ioMessageDTO.getNav()))
       .map(ioMessageDTO -> InstallmentRegistry.builder()
         .eventId(dto.getEventId() + "." + ioMessageDTO.getNav())
         .eventType(dto.getEventType())
@@ -27,7 +27,7 @@ public class DebtPositionIoEventDTO2InstallmentRegistryMapper {
         .organizationId(dto.getPayload().getOrganizationId())
         .nav(ioMessageDTO.getNav())
         .build())
-      .collect(Collectors.toList());
+      .toList();
   }
 
 }

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapper.java
@@ -1,0 +1,44 @@
+package it.gov.pagopa.pu.registry.mapper.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionIoEventDTO;
+import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class DebtPositionIoEventDTO2InstallmentRegistryMapper {
+
+  public List<InstallmentRegistry> map(DebtPositionIoEventDTO dto) {
+    if (dto.getPayload().getMessages() == null) return List.of();
+
+    List<String> iudList;
+
+    if (dto.getEventDescription().startsWith("IUD:")) {
+      iudList = List.of(dto.getEventDescription().split(":")[1].trim().split(","));
+    } else {
+      iudList = null;
+    }
+
+    return dto.getPayload().getMessages().stream()
+      .filter(ioMessageDTO -> {
+        if (iudList == null) return true;
+        return iudList.contains(ioMessageDTO.getNotificationId());
+      })
+      .map(ioMessageDTO -> InstallmentRegistry.builder()
+        .eventId(dto.getEventId() + "." + ioMessageDTO.getNav())
+        .eventType(dto.getEventType())
+        .traceId(dto.getTraceId())
+        .eventDateTime(dto.getEventDateTime())
+        .eventDescription(dto.getEventDescription())
+        .debtPositionId(dto.getPayload().getDebtPositionId())
+        .organizationId(dto.getPayload().getOrganizationId())
+        .nav(ioMessageDTO.getNav())
+        .build())
+      .collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapper.java
@@ -15,19 +15,8 @@ public class DebtPositionIoEventDTO2InstallmentRegistryMapper {
   public List<InstallmentRegistry> map(DebtPositionIoEventDTO dto) {
     if (dto.getPayload().getMessages() == null) return List.of();
 
-    List<String> iudList;
-
-    if (dto.getEventDescription().startsWith("IUD:")) {
-      iudList = List.of(dto.getEventDescription().split(":")[1].trim().split(","));
-    } else {
-      iudList = null;
-    }
-
     return dto.getPayload().getMessages().stream()
-      .filter(ioMessageDTO -> {
-        if (iudList == null) return true;
-        return iudList.contains(ioMessageDTO.getNotificationId());
-      })
+      .filter(ioMessageDTO -> ioMessageDTO.getNav() != null && !ioMessageDTO.getNav().isEmpty())
       .map(ioMessageDTO -> InstallmentRegistry.builder()
         .eventId(dto.getEventId() + "." + ioMessageDTO.getNav())
         .eventType(dto.getEventType())

--- a/src/main/java/it/gov/pagopa/pu/registry/model/DebtPositionRegistry.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/model/DebtPositionRegistry.java
@@ -1,12 +1,7 @@
 package it.gov.pagopa.pu.registry.model;
 
 import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.ToString;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 

--- a/src/main/java/it/gov/pagopa/pu/registry/model/InstallmentRegistry.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/model/InstallmentRegistry.java
@@ -1,12 +1,7 @@
 package it.gov.pagopa.pu.registry.model;
 
 import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.ToString;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 

--- a/src/main/java/it/gov/pagopa/pu/registry/utils/ExtractionUtils.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/utils/ExtractionUtils.java
@@ -7,10 +7,11 @@ import java.util.regex.Pattern;
 
 public class ExtractionUtils {
 
+  private final static Pattern IUD_MATCH_PATTERN = Pattern.compile("IUD:\\s*([^;]*)\\s*(?:;|$)");
+
   public static Set<String> extractIudIdsFromDescription(String description) {
     Set<String> iudIds = new HashSet<>();
-    Pattern pattern = Pattern.compile("IUD:\\s*([^;]*)");
-    Matcher matcher = pattern.matcher(description);
+    Matcher matcher = IUD_MATCH_PATTERN.matcher(description);
 
     if (matcher.find()) {
       String ids = matcher.group(1);

--- a/src/main/java/it/gov/pagopa/pu/registry/utils/ExtractionUtils.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/utils/ExtractionUtils.java
@@ -1,0 +1,29 @@
+package it.gov.pagopa.pu.registry.utils;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ExtractionUtils {
+
+  public static Set<String> extractIudIdsFromDescription(String description) {
+    Set<String> iudIds = new HashSet<>();
+    Pattern pattern = Pattern.compile("IUD:\\s*([^;]*)");
+    Matcher matcher = pattern.matcher(description);
+
+    if (matcher.find()) {
+      String ids = matcher.group(1);
+      String[] splitIds = ids.split(",");
+      for (String id : splitIds) {
+        String trimmedId = id.trim();
+        if (!trimmedId.isEmpty()) {
+          iudIds.add(trimmedId);
+        }
+      }
+    }
+
+    return iudIds;
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/utils/ExtractionUtils.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/utils/ExtractionUtils.java
@@ -7,7 +7,11 @@ import java.util.regex.Pattern;
 
 public class ExtractionUtils {
 
-  private final static Pattern IUD_MATCH_PATTERN = Pattern.compile("IUD:\\s*([^;]*)\\s*(?:;|$)");
+  private ExtractionUtils() {
+    // Constructor is intentionally empty to hide the default public one
+  }
+
+  private static final Pattern IUD_MATCH_PATTERN = Pattern.compile("IUD:\\s*([^;]*)\\s*(?:;|$)");
 
   public static Set<String> extractIudIdsFromDescription(String description) {
     Set<String> iudIds = new HashSet<>();

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionEventDTO2DebtPositionRegistryMapperTest.java
@@ -12,7 +12,7 @@ import java.time.OffsetDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
+class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
 
   private DebtPositionEventDTO2DebtPositionRegistryMapper mapper;
 

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionIoEventDTO2DebtPositionRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionIoEventDTO2DebtPositionRegistryMapperTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DebtPositionIoEventDTO2DebtPositionRegistryMapperTest {
+class DebtPositionIoEventDTO2DebtPositionRegistryMapperTest {
 
   private DebtPositionIoEventDTO2DebtPositionRegistryMapper mapper;
 

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionIoEventDTO2DebtPositionRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionIoEventDTO2DebtPositionRegistryMapperTest.java
@@ -1,0 +1,71 @@
+package it.gov.pagopa.pu.registry.mapper.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionIoEventDTO;
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionIoNotificationDTO;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import it.gov.pagopa.pu.registry.utils.TestUtils;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DebtPositionIoEventDTO2DebtPositionRegistryMapperTest {
+
+  private DebtPositionIoEventDTO2DebtPositionRegistryMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new DebtPositionIoEventDTO2DebtPositionRegistryMapper();
+  }
+
+  @Test
+  void map_shouldMapCorrectly_whenValidInput() {
+    DebtPositionIoEventDTO dto = createValidDto();
+    DebtPositionRegistry result = mapper.map(dto);
+    TestUtils.checkNotNullFields(result, "operatorExternalUserId");
+
+    assertEquals(dto.getEventId(), result.getEventId());
+    assertEquals(dto.getEventType(), result.getEventType());
+    assertEquals(dto.getTraceId(), result.getTraceId());
+    assertEquals(dto.getEventDateTime(), result.getEventDateTime());
+    assertEquals(dto.getEventDescription(), result.getEventDescription());
+    assertEquals(dto.getPayload().getDebtPositionId(), result.getDebtPositionId());
+    assertEquals(dto.getPayload().getOrganizationId(), result.getOrganizationId());
+  }
+
+  private DebtPositionIoEventDTO createValidDto() {
+    List<DebtPositionIoNotificationDTO.IoMessage> ioMessagess = List.of(
+      DebtPositionIoNotificationDTO.IoMessage.builder()
+        .serviceId("serviceId1")
+        .nav("nav1")
+        .notificationId("notificationId1")
+        .build(),
+      DebtPositionIoNotificationDTO.IoMessage.builder()
+        .serviceId("serviceId2")
+        .nav("nav2")
+        .notificationId("notificationId2")
+        .build()
+    );
+
+    DebtPositionIoNotificationDTO payload = DebtPositionIoNotificationDTO.builder()
+      .debtPositionId(123L)
+      .debtPositionTypeOrgId(456L)
+      .organizationId(789L)
+      .messages(ioMessagess)
+      .build();
+
+    return DebtPositionIoEventDTO.builder()
+      .eventId("eventId1")
+      .eventType(PaymentEventType.DP_CREATED)
+      .traceId("traceId2")
+      .eventDateTime(OffsetDateTime.now())
+      .eventDescription("Some event description")
+      .payload(payload)
+      .build();
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionEventDTO2InstallmentRegistryMapperTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
+class DebtPositionEventDTO2InstallmentRegistryMapperTest {
 
   private DebtPositionEventDTO2InstallmentRegistryMapper mapper;
 

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapperTest.java
@@ -31,7 +31,7 @@ public class DebtPositionIoEventDTO2InstallmentRegistryMapperTest {
     });
 
     assertEquals(2, result.size());
-    assertEquals(2, dto.getPayload().getMessages().size());
+    assertEquals(4, dto.getPayload().getMessages().size());
     assertEquals(dto.getEventType(), result.getFirst().getEventType());
     assertEquals(dto.getTraceId(), result.getFirst().getTraceId());
     assertEquals(dto.getEventDateTime(), result.getFirst().getEventDateTime());
@@ -48,20 +48,6 @@ public class DebtPositionIoEventDTO2InstallmentRegistryMapperTest {
     assertEquals(secondInstallmentDTO.getNav(), result.get(1).getNav());
   }
 
-  @Test
-  void map_shouldFilterOut_whenIUDNotPresentInDescription() {
-    DebtPositionIoEventDTO dto = createValidDto();
-    dto.setEventDescription("IUD: notificationId1");
-    List<InstallmentRegistry> result = mapper.map(dto);
-    result.forEach(installmentRegistry -> {
-      TestUtils.checkNotNullFields(installmentRegistry, "operatorExternalUserId");
-    });
-
-    assertEquals(1, result.size());
-    assertEquals(2, dto.getPayload().getMessages().size());
-    assertEquals("nav1", result.getFirst().getNav());
-  }
-
   private DebtPositionIoEventDTO createValidDto() {
     List<DebtPositionIoNotificationDTO.IoMessage> ioMessagess = List.of(
       DebtPositionIoNotificationDTO.IoMessage.builder()
@@ -73,6 +59,16 @@ public class DebtPositionIoEventDTO2InstallmentRegistryMapperTest {
         .serviceId("serviceId2")
         .nav("nav2")
         .notificationId("notificationId2")
+        .build(),
+      DebtPositionIoNotificationDTO.IoMessage.builder()
+        .serviceId("serviceId3")
+        .nav(null)
+        .notificationId("notificationId3")
+        .build(),
+      DebtPositionIoNotificationDTO.IoMessage.builder()
+        .serviceId("serviceId4")
+        .nav("")
+        .notificationId("notificationId4")
         .build()
     );
 

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapperTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DebtPositionIoEventDTO2InstallmentRegistryMapperTest {
+class DebtPositionIoEventDTO2InstallmentRegistryMapperTest {
 
   private DebtPositionIoEventDTO2InstallmentRegistryMapper mapper;
 

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionIoEventDTO2InstallmentRegistryMapperTest.java
@@ -1,0 +1,96 @@
+package it.gov.pagopa.pu.registry.mapper.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionIoEventDTO;
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionIoNotificationDTO;
+import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import it.gov.pagopa.pu.registry.utils.TestUtils;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DebtPositionIoEventDTO2InstallmentRegistryMapperTest {
+
+  private DebtPositionIoEventDTO2InstallmentRegistryMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new DebtPositionIoEventDTO2InstallmentRegistryMapper();
+  }
+
+  @Test
+  void map_shouldMapCorrectly_whenValidInput() {
+    DebtPositionIoEventDTO dto = createValidDto();
+    List<InstallmentRegistry> result = mapper.map(dto);
+    result.forEach(installmentRegistry -> {
+      TestUtils.checkNotNullFields(installmentRegistry, "operatorExternalUserId");
+    });
+
+    assertEquals(2, result.size());
+    assertEquals(2, dto.getPayload().getMessages().size());
+    assertEquals(dto.getEventType(), result.getFirst().getEventType());
+    assertEquals(dto.getTraceId(), result.getFirst().getTraceId());
+    assertEquals(dto.getEventDateTime(), result.getFirst().getEventDateTime());
+    assertEquals(dto.getEventDescription(), result.getFirst().getEventDescription());
+    assertEquals(dto.getPayload().getDebtPositionId(), result.getFirst().getDebtPositionId());
+    assertEquals(dto.getPayload().getOrganizationId(), result.getFirst().getOrganizationId());
+
+    DebtPositionIoNotificationDTO.IoMessage firstInstallmentDTO = dto.getPayload().getMessages().getFirst();
+    DebtPositionIoNotificationDTO.IoMessage secondInstallmentDTO = dto.getPayload().getMessages().get(1);
+    assertEquals(dto.getEventId() + "." + firstInstallmentDTO.getNav(), result.get(0).getEventId());
+    assertEquals(firstInstallmentDTO.getNav(), result.get(0).getNav());
+
+    assertEquals(dto.getEventId() + "." + secondInstallmentDTO.getNav(), result.get(1).getEventId());
+    assertEquals(secondInstallmentDTO.getNav(), result.get(1).getNav());
+  }
+
+  @Test
+  void map_shouldFilterOut_whenIUDNotPresentInDescription() {
+    DebtPositionIoEventDTO dto = createValidDto();
+    dto.setEventDescription("IUD: notificationId1");
+    List<InstallmentRegistry> result = mapper.map(dto);
+    result.forEach(installmentRegistry -> {
+      TestUtils.checkNotNullFields(installmentRegistry, "operatorExternalUserId");
+    });
+
+    assertEquals(1, result.size());
+    assertEquals(2, dto.getPayload().getMessages().size());
+    assertEquals("nav1", result.getFirst().getNav());
+  }
+
+  private DebtPositionIoEventDTO createValidDto() {
+    List<DebtPositionIoNotificationDTO.IoMessage> ioMessagess = List.of(
+      DebtPositionIoNotificationDTO.IoMessage.builder()
+        .serviceId("serviceId1")
+        .nav("nav1")
+        .notificationId("notificationId1")
+        .build(),
+      DebtPositionIoNotificationDTO.IoMessage.builder()
+        .serviceId("serviceId2")
+        .nav("nav2")
+        .notificationId("notificationId2")
+        .build()
+    );
+
+    DebtPositionIoNotificationDTO payload = DebtPositionIoNotificationDTO.builder()
+      .debtPositionId(123L)
+      .debtPositionTypeOrgId(456L)
+      .organizationId(789L)
+      .messages(ioMessagess)
+      .build();
+
+    return DebtPositionIoEventDTO.builder()
+      .eventId("eventId1")
+      .eventType(PaymentEventType.DP_CREATED)
+      .traceId("traceId2")
+      .eventDateTime(OffsetDateTime.now())
+      .eventDescription("Some event description")
+      .payload(payload)
+      .build();
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/utils/ExtractionUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/utils/ExtractionUtilsTest.java
@@ -14,14 +14,17 @@ public class ExtractionUtilsTest {
     String str1 = "IUD: id1, id2, id3; CODE: code1, code2;";
     String str2 = "Hello world. IUD: id4, id5 ; CODE: c1;";
     String str3 = "Hello. CODE: c2; IUD: id6, id7, id8  ;";
+    String str4 = "IUD: id1, id2, id3 ";
 
     Set<String> expected1 = Set.of("id1", "id2", "id3");
     Set<String> expected2 = Set.of("id4", "id5");
     Set<String> expected3 = Set.of("id6", "id7", "id8");
+    Set<String> expected4 = Set.of("id1", "id2", "id3");
 
     assertEquals(expected1, ExtractionUtils.extractIudIdsFromDescription(str1));
     assertEquals(expected2, ExtractionUtils.extractIudIdsFromDescription(str2));
     assertEquals(expected3, ExtractionUtils.extractIudIdsFromDescription(str3));
+    assertEquals(expected4, ExtractionUtils.extractIudIdsFromDescription(str4));
   }
 
   @Test

--- a/src/test/java/it/gov/pagopa/pu/registry/utils/ExtractionUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/utils/ExtractionUtilsTest.java
@@ -1,0 +1,38 @@
+package it.gov.pagopa.pu.registry.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExtractionUtilsTest {
+
+  @Test
+  void testExtractIuds_present() {
+    String str1 = "IUD: id1, id2, id3; CODE: code1, code2;";
+    String str2 = "Hello world. IUD: id4, id5 ; CODE: c1;";
+    String str3 = "Hello. CODE: c2; IUD: id6, id7, id8  ;";
+
+    Set<String> expected1 = Set.of("id1", "id2", "id3");
+    Set<String> expected2 = Set.of("id4", "id5");
+    Set<String> expected3 = Set.of("id6", "id7", "id8");
+
+    assertEquals(expected1, ExtractionUtils.extractIudIdsFromDescription(str1));
+    assertEquals(expected2, ExtractionUtils.extractIudIdsFromDescription(str2));
+    assertEquals(expected3, ExtractionUtils.extractIudIdsFromDescription(str3));
+  }
+
+  @Test
+  void testExtractIuds_absent() {
+    String str1 = "Hello there. IUD code1, code2";
+    String str2 = "Completely unrelated text.";
+    String str3 = "";
+
+    assertTrue(ExtractionUtils.extractIudIdsFromDescription(str1).isEmpty());
+    assertTrue(ExtractionUtils.extractIudIdsFromDescription(str2).isEmpty());
+    assertTrue(ExtractionUtils.extractIudIdsFromDescription(str3).isEmpty());
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/utils/ExtractionUtilsTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/utils/ExtractionUtilsTest.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ExtractionUtilsTest {
+class ExtractionUtilsTest {
 
   @Test
   void testExtractIuds_present() {


### PR DESCRIPTION
#### Description
Created two mapper services that take as input a `DebtPositionIoEvent` and maps it to a `DebtPositionRegistry` or multiple `InstallmentRegistry` for tracing.

#### List of Changes
* Created the mapper `DebtPositionIoEventDTO2DebtPositionRegistryMapper` for `DebtPositionIoEventDTO` conversion into `DebtPositionRegistry` entity with relative unit tests
* Created the mapper `DebtPositionIoEventDTO2InstallmentRegistryMapper` for `DebtPositionIoEventDTO` conversion into `InstallmentRegistry` entity with relative unit tests

#### Motivation and Context
To handle the history and tracing of all the debt position events.

#### How Has This Been Tested?
- Pre-Deploy Test
  - [x] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load