### PR TITLE
feat: P4ADEV-2798 Implemented debt position send event mappers

### DIFF
--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionSendEventDTO2DebtPositionRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionSendEventDTO2DebtPositionRegistryMapper.java
@@ -1,0 +1,24 @@
+package it.gov.pagopa.pu.registry.mapper.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionSendEventDTO;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class DebtPositionSendEventDTO2DebtPositionRegistryMapper {
+
+  public DebtPositionRegistry map(DebtPositionSendEventDTO dto) {
+    return DebtPositionRegistry.builder()
+      .eventId(dto.getEventId())
+      .eventType(dto.getEventType())
+      .traceId(dto.getTraceId())
+      .eventDateTime(dto.getEventDateTime())
+      .eventDescription(dto.getEventDescription())
+      .debtPositionId(dto.getPayload().getDebtPositionId())
+      .organizationId(dto.getPayload().getOrganizationId())
+      .build();
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionSendEventDTO2InstallmentRegistryMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionSendEventDTO2InstallmentRegistryMapper.java
@@ -1,0 +1,32 @@
+package it.gov.pagopa.pu.registry.mapper.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionSendEventDTO;
+import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class DebtPositionSendEventDTO2InstallmentRegistryMapper {
+
+  public List<InstallmentRegistry> map(DebtPositionSendEventDTO dto) {
+    if (dto.getPayload().getNoticeCodes() == null) return List.of();
+
+    return dto.getPayload().getNoticeCodes().stream()
+      .map(noticeCode -> InstallmentRegistry.builder()
+        .eventId(dto.getEventId() + "." + noticeCode)
+        .eventType(dto.getEventType())
+        .traceId(dto.getTraceId())
+        .eventDateTime(dto.getEventDateTime())
+        .eventDescription(dto.getEventDescription())
+        .debtPositionId(dto.getPayload().getDebtPositionId())
+        .organizationId(dto.getPayload().getOrganizationId())
+        .nav(noticeCode)
+        .build())
+      .collect(Collectors.toList());
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionSendEventDTO2DebtPositionRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionSendEventDTO2DebtPositionRegistryMapperTest.java
@@ -1,31 +1,32 @@
 package it.gov.pagopa.pu.registry.mapper.debtposition;
 
-import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionSendEventDTO;
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionSendNotificationDTO;
 import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
 import it.gov.pagopa.pu.registry.utils.TestUtils;
-import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
 import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
+public class DebtPositionSendEventDTO2DebtPositionRegistryMapperTest {
 
-  private DebtPositionEventDTO2DebtPositionRegistryMapper mapper;
+  private DebtPositionSendEventDTO2DebtPositionRegistryMapper mapper;
 
   @BeforeEach
   void setUp() {
-    mapper = new DebtPositionEventDTO2DebtPositionRegistryMapper();
+    mapper = new DebtPositionSendEventDTO2DebtPositionRegistryMapper();
   }
 
   @Test
   void map_shouldMapCorrectly_whenValidInput() {
-    DebtPositionEventDTO dto = createValidDto();
+    DebtPositionSendEventDTO dto = createValidDto();
     DebtPositionRegistry result = mapper.map(dto);
-    TestUtils.checkNotNullFields(result);
+    TestUtils.checkNotNullFields(result, "operatorExternalUserId");
 
     assertEquals(dto.getEventId(), result.getEventId());
     assertEquals(dto.getEventType(), result.getEventType());
@@ -33,18 +34,17 @@ public class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
     assertEquals(dto.getEventDateTime(), result.getEventDateTime());
     assertEquals(dto.getEventDescription(), result.getEventDescription());
     assertEquals(dto.getPayload().getDebtPositionId(), result.getDebtPositionId());
-    assertEquals(dto.getPayload().getUpdateOperatorExternalId(), result.getOperatorExternalUserId());
     assertEquals(dto.getPayload().getOrganizationId(), result.getOrganizationId());
   }
 
-  private DebtPositionEventDTO createValidDto() {
-    DebtPositionDTO payload = DebtPositionDTO.builder()
+  private DebtPositionSendEventDTO createValidDto() {
+    DebtPositionSendNotificationDTO payload = DebtPositionSendNotificationDTO.builder()
       .debtPositionId(123L)
-      .updateOperatorExternalId("externalOperatorId456")
       .organizationId(789L)
+      .noticeCodes(List.of("nav1", "nav2"))
       .build();
 
-    return DebtPositionEventDTO.builder()
+    return DebtPositionSendEventDTO.builder()
       .eventId("eventId1")
       .eventType(PaymentEventType.DP_CREATED)
       .traceId("traceId2")

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionSendEventDTO2DebtPositionRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionSendEventDTO2DebtPositionRegistryMapperTest.java
@@ -1,0 +1,57 @@
+package it.gov.pagopa.pu.registry.mapper.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import it.gov.pagopa.pu.registry.utils.TestUtils;
+import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DebtPositionEventDTO2DebtPositionRegistryMapperTest {
+
+  private DebtPositionEventDTO2DebtPositionRegistryMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new DebtPositionEventDTO2DebtPositionRegistryMapper();
+  }
+
+  @Test
+  void map_shouldMapCorrectly_whenValidInput() {
+    DebtPositionEventDTO dto = createValidDto();
+    DebtPositionRegistry result = mapper.map(dto);
+    TestUtils.checkNotNullFields(result);
+
+    assertEquals(dto.getEventId(), result.getEventId());
+    assertEquals(dto.getEventType(), result.getEventType());
+    assertEquals(dto.getTraceId(), result.getTraceId());
+    assertEquals(dto.getEventDateTime(), result.getEventDateTime());
+    assertEquals(dto.getEventDescription(), result.getEventDescription());
+    assertEquals(dto.getPayload().getDebtPositionId(), result.getDebtPositionId());
+    assertEquals(dto.getPayload().getUpdateOperatorExternalId(), result.getOperatorExternalUserId());
+    assertEquals(dto.getPayload().getOrganizationId(), result.getOrganizationId());
+  }
+
+  private DebtPositionEventDTO createValidDto() {
+    DebtPositionDTO payload = DebtPositionDTO.builder()
+      .debtPositionId(123L)
+      .updateOperatorExternalId("externalOperatorId456")
+      .organizationId(789L)
+      .build();
+
+    return DebtPositionEventDTO.builder()
+      .eventId("eventId1")
+      .eventType(PaymentEventType.DP_CREATED)
+      .traceId("traceId2")
+      .eventDateTime(OffsetDateTime.now())
+      .eventDescription("Some event description")
+      .payload(payload)
+      .build();
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionSendEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionSendEventDTO2InstallmentRegistryMapperTest.java
@@ -1,0 +1,92 @@
+package it.gov.pagopa.pu.registry.mapper.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
+import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import it.gov.pagopa.pu.registry.utils.TestUtils;
+import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.InstallmentDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentOptionDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
+
+  private DebtPositionEventDTO2InstallmentRegistryMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new DebtPositionEventDTO2InstallmentRegistryMapper();
+  }
+
+  @Test
+  void map_shouldMapCorrectly_whenValidInput() {
+    DebtPositionEventDTO dto = createValidDto();
+    List<InstallmentRegistry> result = mapper.map(dto);
+    result.forEach(TestUtils::checkNotNullFields);
+
+    assertEquals(2, result.size());
+    assertNotNull(dto.getPayload().getPaymentOptions());
+    assertNotNull(dto.getPayload().getPaymentOptions().getFirst().getInstallments());
+    assertEquals(dto.getEventType(), result.getFirst().getEventType());
+    assertEquals(dto.getTraceId(), result.getFirst().getTraceId());
+    assertEquals(dto.getEventDateTime(), result.getFirst().getEventDateTime());
+    assertEquals(dto.getEventDescription(), result.getFirst().getEventDescription());
+    assertEquals(dto.getPayload().getDebtPositionId(), result.getFirst().getDebtPositionId());
+    assertEquals(dto.getPayload().getOrganizationId(), result.getFirst().getOrganizationId());
+
+    InstallmentDTO firstInstallmentDTO = dto.getPayload().getPaymentOptions().getFirst().getInstallments().get(0);
+    InstallmentDTO secondInstallmentDTO = dto.getPayload().getPaymentOptions().getFirst().getInstallments().get(1);
+    TestUtils.checkNotNullFields(result.get(0));
+    TestUtils.checkNotNullFields(result.get(1));
+    assertEquals(dto.getEventId() + "." + firstInstallmentDTO.getNav(), result.get(0).getEventId());
+    assertEquals(firstInstallmentDTO.getNav(), result.get(0).getNav());
+    assertEquals(firstInstallmentDTO.getUpdateOperatorExternalId(), result.get(0).getOperatorExternalUserId());
+
+    assertEquals(dto.getEventId() + "." + secondInstallmentDTO.getNav(), result.get(1).getEventId());
+    assertEquals(secondInstallmentDTO.getNav(), result.get(1).getNav());
+    assertEquals(secondInstallmentDTO.getUpdateOperatorExternalId(), result.get(1).getOperatorExternalUserId());
+  }
+
+  private DebtPositionEventDTO createValidDto() {
+    List<InstallmentDTO> installments = List.of(
+      InstallmentDTO.builder()
+        .nav("nav1")
+        .updateOperatorExternalId("operatorExternalId123")
+        .build(),
+      InstallmentDTO.builder()
+        .nav("nav2")
+        .updateOperatorExternalId("operatorExternalId456")
+        .build()
+    );
+
+    List<PaymentOptionDTO> paymentOptions = List.of(
+      PaymentOptionDTO.builder()
+        .installments(installments)
+        .build()
+    );
+
+    DebtPositionDTO payload = DebtPositionDTO.builder()
+      .debtPositionId(123L)
+      .updateOperatorExternalId("externalOperatorId456")
+      .organizationId(789L)
+      .paymentOptions(paymentOptions)
+      .build();
+
+    return DebtPositionEventDTO.builder()
+      .eventId("eventId1")
+      .eventType(PaymentEventType.DP_CREATED)
+      .traceId("traceId2")
+      .eventDateTime(OffsetDateTime.now())
+      .eventDescription("Some event description")
+      .payload(payload)
+      .build();
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionSendEventDTO2InstallmentRegistryMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/DebtPositionSendEventDTO2InstallmentRegistryMapperTest.java
@@ -1,12 +1,10 @@
 package it.gov.pagopa.pu.registry.mapper.installment;
 
-import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionEventDTO;
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionSendEventDTO;
+import it.gov.pagopa.pu.registry.event.payments.dto.DebtPositionSendNotificationDTO;
 import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
 import it.gov.pagopa.pu.registry.utils.TestUtils;
-import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
-import it.gov.pagopa.pu.workflowhub.dto.generated.InstallmentDTO;
 import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
-import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentOptionDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,72 +12,48 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class DebtPositionEventDTO2InstallmentRegistryMapperTest {
+public class DebtPositionSendEventDTO2InstallmentRegistryMapperTest {
 
-  private DebtPositionEventDTO2InstallmentRegistryMapper mapper;
+  private DebtPositionSendEventDTO2InstallmentRegistryMapper mapper;
 
   @BeforeEach
   void setUp() {
-    mapper = new DebtPositionEventDTO2InstallmentRegistryMapper();
+    mapper = new DebtPositionSendEventDTO2InstallmentRegistryMapper();
   }
 
   @Test
   void map_shouldMapCorrectly_whenValidInput() {
-    DebtPositionEventDTO dto = createValidDto();
+    DebtPositionSendEventDTO dto = createValidDto();
     List<InstallmentRegistry> result = mapper.map(dto);
-    result.forEach(TestUtils::checkNotNullFields);
+    result.forEach(installmentRegistry -> {
+      TestUtils.checkNotNullFields(installmentRegistry, "operatorExternalUserId");
+    });
 
     assertEquals(2, result.size());
-    assertNotNull(dto.getPayload().getPaymentOptions());
-    assertNotNull(dto.getPayload().getPaymentOptions().getFirst().getInstallments());
     assertEquals(dto.getEventType(), result.getFirst().getEventType());
     assertEquals(dto.getTraceId(), result.getFirst().getTraceId());
     assertEquals(dto.getEventDateTime(), result.getFirst().getEventDateTime());
     assertEquals(dto.getEventDescription(), result.getFirst().getEventDescription());
     assertEquals(dto.getPayload().getDebtPositionId(), result.getFirst().getDebtPositionId());
     assertEquals(dto.getPayload().getOrganizationId(), result.getFirst().getOrganizationId());
+    String firstNoticeCode = dto.getPayload().getNoticeCodes().get(0);
+    String secondNoticeCode = dto.getPayload().getNoticeCodes().get(1);
+    assertEquals(dto.getEventId() + "." + firstNoticeCode, result.getFirst().getEventId());
+    assertEquals(firstNoticeCode, result.getFirst().getNav());
 
-    InstallmentDTO firstInstallmentDTO = dto.getPayload().getPaymentOptions().getFirst().getInstallments().get(0);
-    InstallmentDTO secondInstallmentDTO = dto.getPayload().getPaymentOptions().getFirst().getInstallments().get(1);
-    TestUtils.checkNotNullFields(result.get(0));
-    TestUtils.checkNotNullFields(result.get(1));
-    assertEquals(dto.getEventId() + "." + firstInstallmentDTO.getNav(), result.get(0).getEventId());
-    assertEquals(firstInstallmentDTO.getNav(), result.get(0).getNav());
-    assertEquals(firstInstallmentDTO.getUpdateOperatorExternalId(), result.get(0).getOperatorExternalUserId());
-
-    assertEquals(dto.getEventId() + "." + secondInstallmentDTO.getNav(), result.get(1).getEventId());
-    assertEquals(secondInstallmentDTO.getNav(), result.get(1).getNav());
-    assertEquals(secondInstallmentDTO.getUpdateOperatorExternalId(), result.get(1).getOperatorExternalUserId());
+    assertEquals(dto.getEventId() + "." + secondNoticeCode, result.get(1).getEventId());
+    assertEquals(secondNoticeCode, result.get(1).getNav());
   }
 
-  private DebtPositionEventDTO createValidDto() {
-    List<InstallmentDTO> installments = List.of(
-      InstallmentDTO.builder()
-        .nav("nav1")
-        .updateOperatorExternalId("operatorExternalId123")
-        .build(),
-      InstallmentDTO.builder()
-        .nav("nav2")
-        .updateOperatorExternalId("operatorExternalId456")
-        .build()
-    );
-
-    List<PaymentOptionDTO> paymentOptions = List.of(
-      PaymentOptionDTO.builder()
-        .installments(installments)
-        .build()
-    );
-
-    DebtPositionDTO payload = DebtPositionDTO.builder()
+  private DebtPositionSendEventDTO createValidDto() {
+    DebtPositionSendNotificationDTO payload = DebtPositionSendNotificationDTO.builder()
       .debtPositionId(123L)
-      .updateOperatorExternalId("externalOperatorId456")
       .organizationId(789L)
-      .paymentOptions(paymentOptions)
+      .noticeCodes(List.of("nav1", "nav2"))
       .build();
 
-    return DebtPositionEventDTO.builder()
+    return DebtPositionSendEventDTO.builder()
       .eventId("eventId1")
       .eventType(PaymentEventType.DP_CREATED)
       .traceId("traceId2")


### PR DESCRIPTION
#### Description
Created two mapper services that take as input a `DebtPositionSendEvent` and maps it to a `DebtPositionRegistry` or multiple `InstallmentRegistry` for tracing.

#### List of Changes
* Created the mapper `DebtPositionSendEventDTO2DebtPositionRegistryMapper` for `DebtPositionSendEventDTO` conversion into `DebtPositionRegistry` entity with relative unit tests
* Created the mapper `DebtPositionSendEventDTO2InstallmentRegistryMapper` for `DebtPositionSendEventDTO` conversion into `InstallmentRegistry` entity with relative unit tests

#### Motivation and Context
To handle the history and tracing of all the debt position events.

#### How Has This Been Tested?
- Pre-Deploy Test
  - [x] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load