### PR TITLE
P4ADEV-2799, P4ADEV-2800, P4ADEV-2801, P4ADEV-2802, P4ADEV-2803

### DIFF
--- a/src/main/java/it/gov/pagopa/pu/registry/event/payments/PaymentsConsumer.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/event/payments/PaymentsConsumer.java
@@ -1,6 +1,8 @@
 package it.gov.pagopa.pu.registry.event.payments;
 
 import it.gov.pagopa.pu.registry.event.payments.dto.PaymentEventDTO;
+import it.gov.pagopa.pu.registry.service.TimelineService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -9,11 +11,19 @@ import java.util.function.Consumer;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class PaymentsConsumer implements Consumer<PaymentEventDTO<?>> {
+
+  private final TimelineService timelineService;
 
   @Override
   public void accept(PaymentEventDTO paymentEventDTO) {
     log.info("Read eventId {} of type eventType {}", paymentEventDTO.getEventId(), paymentEventDTO.getEventType());
+    try {
+      timelineService.consumePaymentEvent(paymentEventDTO);
+    } catch (Exception exception) {
+      log.error("Error processing payment event: {}", paymentEventDTO, exception);
+    }
   }
 
 }

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionRegistryMapperService.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionRegistryMapperService.java
@@ -1,0 +1,57 @@
+package it.gov.pagopa.pu.registry.mapper.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.*;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DebtPositionRegistryMapperService {
+
+  private final DebtPositionEventDTO2DebtPositionRegistryMapper debtPositionEventDTO2DebtPositionRegistryMapper;
+  private final DebtPositionIoEventDTO2DebtPositionRegistryMapper debtPositionIoEventDTO2DebtPositionRegistryMapper;
+  private final DebtPositionSendEventDTO2DebtPositionRegistryMapper debtPositionSendEventDTO2DebtPositionRegistryMapper;
+
+  public DebtPositionRegistry map(PaymentEventDTO<?> event) {
+    if (event == null) {
+      log.warn("Received null event");
+      return null;
+    }
+
+    if (event.getPayload() == null) {
+      log.warn("Received event with null payload: eventType={} eventId={} traceId={} eventDescription={}",
+               event.getEventType(), event.getEventId(), event.getTraceId(), event.getEventDescription());
+      return null;
+    }
+
+    if (event.getEventType() == null) {
+      log.warn("Received event with null event type: eventId={} traceId={} eventDescription={}",
+               event.getEventId(), event.getTraceId(), event.getEventDescription());
+      return null;
+    }
+
+    Object payload = event.getPayload();
+
+    switch (payload) {
+      case DebtPositionDTO debtPositionDTO -> {
+        return debtPositionEventDTO2DebtPositionRegistryMapper.map((DebtPositionEventDTO) event);
+      }
+      case DebtPositionIoNotificationDTO debtPositionIoNotificationDTO -> {
+        return debtPositionIoEventDTO2DebtPositionRegistryMapper.map((DebtPositionIoEventDTO) event);
+      }
+      case DebtPositionSendNotificationDTO debtPositionSendNotificationDTO -> {
+        return debtPositionSendEventDTO2DebtPositionRegistryMapper.map((DebtPositionSendEventDTO) event);
+      }
+      default -> {
+        log.warn("Unsupported payload type: class={} eventType={} eventId={} traceId={} eventDescription={}", payload.getClass().getName(),
+          event.getEventType(), event.getEventId(), event.getTraceId(), event.getEventDescription());
+        return null;
+      }
+    }
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/InstallmentRegistryMapperService.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/mapper/installment/InstallmentRegistryMapperService.java
@@ -1,0 +1,58 @@
+package it.gov.pagopa.pu.registry.mapper.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.*;
+import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class InstallmentRegistryMapperService {
+
+  private final DebtPositionEventDTO2InstallmentRegistryMapper debtPositionEventDTO2InstallmentRegistryMapper;
+  private final DebtPositionIoEventDTO2InstallmentRegistryMapper debtPositionIoEventDTO2DebtPositionRegistryMapper;
+  private final DebtPositionSendEventDTO2InstallmentRegistryMapper debtPositionSendEventDTO2DebtPositionRegistryMapper;
+
+  public List<InstallmentRegistry> map(PaymentEventDTO<?> event) {
+    if (event == null) {
+      return List.of();
+    }
+
+    if (event.getPayload() == null) {
+      log.warn("Received event with null payload: eventType={} eventId={} traceId={} eventDescription={}",
+        event.getEventType(), event.getEventId(), event.getTraceId(), event.getEventDescription());
+      return List.of();
+    }
+
+    if (event.getEventType() == null) {
+      log.warn("Received event with null event type: eventId={} traceId={} eventDescription={}",
+        event.getEventId(), event.getTraceId(), event.getEventDescription());
+      return List.of();
+    }
+
+    Object payload = event.getPayload();
+
+    switch (payload) {
+      case DebtPositionDTO debtPositionDTO -> {
+        return debtPositionEventDTO2InstallmentRegistryMapper.map((DebtPositionEventDTO) event);
+      }
+      case DebtPositionIoNotificationDTO debtPositionIoNotificationDTO -> {
+        return debtPositionIoEventDTO2DebtPositionRegistryMapper.map((DebtPositionIoEventDTO) event);
+      }
+      case DebtPositionSendNotificationDTO debtPositionSendNotificationDTO -> {
+        return debtPositionSendEventDTO2DebtPositionRegistryMapper.map((DebtPositionSendEventDTO) event);
+      }
+      default -> {
+        log.warn("Unsupported payload type: class={} eventType={} eventId={} traceId={} eventDescription={}", payload.getClass().getName(),
+          event.getEventType(), event.getEventId(), event.getTraceId(), event.getEventDescription());
+        return List.of();
+      }
+    }
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/service/TimelineService.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/service/TimelineService.java
@@ -16,6 +16,11 @@ public class TimelineService {
   private final InstallmentRegistryService installmentRegistryService;
 
   public void consumePaymentEvent(PaymentEventDTO<?> event) {
+    if (event == null) {
+      log.warn("Received null payment event, skipping processing.");
+      return;
+    }
+
     log.info("Processing payment event: {}", event);
     debtPositionRegistryService.consumePaymentEvent(event);
     installmentRegistryService.consumePaymentEvent(event);

--- a/src/main/java/it/gov/pagopa/pu/registry/service/TimelineService.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/service/TimelineService.java
@@ -1,0 +1,24 @@
+package it.gov.pagopa.pu.registry.service;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.PaymentEventDTO;
+import it.gov.pagopa.pu.registry.service.debtposition.DebtPositionRegistryService;
+import it.gov.pagopa.pu.registry.service.installment.InstallmentRegistryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TimelineService {
+
+  private final DebtPositionRegistryService debtPositionRegistryService;
+  private final InstallmentRegistryService installmentRegistryService;
+
+  public void consumePaymentEvent(PaymentEventDTO<?> event) {
+    log.info("Processing payment event: {}", event);
+    debtPositionRegistryService.consumePaymentEvent(event);
+    installmentRegistryService.consumePaymentEvent(event);
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/service/debtposition/DebtPositionRegistryService.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/service/debtposition/DebtPositionRegistryService.java
@@ -1,0 +1,27 @@
+package it.gov.pagopa.pu.registry.service.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.PaymentEventDTO;
+import it.gov.pagopa.pu.registry.mapper.debtposition.DebtPositionRegistryMapperService;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import it.gov.pagopa.pu.registry.repository.DebtPositionRegistryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DebtPositionRegistryService {
+
+  private final DebtPositionRegistryMapperService debtPositionRegistryMapperService;
+  private final DebtPositionRegistryRepository debtPositionRegistryRepository;
+
+  @Transactional
+  public void consumePaymentEvent(PaymentEventDTO<?> event) {
+    DebtPositionRegistry registry = debtPositionRegistryMapperService.map(event);
+    if (registry == null) return;
+    debtPositionRegistryRepository.save(registry);
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/pu/registry/service/installment/InstallmentRegistryService.java
+++ b/src/main/java/it/gov/pagopa/pu/registry/service/installment/InstallmentRegistryService.java
@@ -1,0 +1,24 @@
+package it.gov.pagopa.pu.registry.service.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.PaymentEventDTO;
+import it.gov.pagopa.pu.registry.mapper.installment.InstallmentRegistryMapperService;
+import it.gov.pagopa.pu.registry.repository.InstallmentRegistryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class InstallmentRegistryService {
+
+  private final InstallmentRegistryMapperService installmentRegistryMapperService;
+  private final InstallmentRegistryRepository installmentRegistryRepository;
+
+  @Transactional
+  public void consumePaymentEvent(PaymentEventDTO<?> event) {
+    installmentRegistryRepository.saveAll(installmentRegistryMapperService.map(event));
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionRegistryMapperServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/debtposition/DebtPositionRegistryMapperServiceTest.java
@@ -1,0 +1,57 @@
+package it.gov.pagopa.pu.registry.mapper.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.*;
+import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DebtPositionRegistryMapperServiceTest {
+
+  private DebtPositionRegistryMapperService debtPositionRegistryMapperService;
+  private DebtPositionEventDTO2DebtPositionRegistryMapper debtPositionEventDTO2DebtPositionRegistryMapper;
+  private DebtPositionIoEventDTO2DebtPositionRegistryMapper debtPositionIoEventDTO2DebtPositionRegistryMapper;
+  private DebtPositionSendEventDTO2DebtPositionRegistryMapper debtPositionSendEventDTO2DebtPositionRegistryMapper;
+
+  @BeforeEach
+  void setUp() {
+    this.debtPositionEventDTO2DebtPositionRegistryMapper = Mockito.spy(new DebtPositionEventDTO2DebtPositionRegistryMapper());
+    this.debtPositionIoEventDTO2DebtPositionRegistryMapper = Mockito.spy(new DebtPositionIoEventDTO2DebtPositionRegistryMapper());
+    this.debtPositionSendEventDTO2DebtPositionRegistryMapper = Mockito.spy(new DebtPositionSendEventDTO2DebtPositionRegistryMapper());
+
+    debtPositionRegistryMapperService = new DebtPositionRegistryMapperService(
+        debtPositionEventDTO2DebtPositionRegistryMapper,
+        debtPositionIoEventDTO2DebtPositionRegistryMapper,
+        debtPositionSendEventDTO2DebtPositionRegistryMapper
+    );
+  }
+
+  @Test
+  void map_shouldReturnDebtPositionRegistry_whenEventIsDebtPositionEvent() {
+    DebtPositionEventDTO dto = new DebtPositionEventDTO();
+    dto.setEventType(PaymentEventType.DP_CREATED);
+    dto.setPayload(new DebtPositionDTO());
+    this.debtPositionRegistryMapperService.map(dto);
+    Mockito.verify(debtPositionEventDTO2DebtPositionRegistryMapper, Mockito.times(1)).map(Mockito.any(DebtPositionEventDTO.class));
+  }
+
+  @Test
+  void map_shouldReturnDebtPositionRegistry_whenEventIsDebtPositionIoEvent() {
+    DebtPositionIoEventDTO dto = new DebtPositionIoEventDTO();
+    dto.setEventType(PaymentEventType.IO_NOTIFIED);
+    dto.setPayload(new DebtPositionIoNotificationDTO());
+    this.debtPositionRegistryMapperService.map(dto);
+    Mockito.verify(debtPositionIoEventDTO2DebtPositionRegistryMapper, Mockito.times(1)).map(Mockito.any(DebtPositionIoEventDTO.class));
+  }
+
+  @Test
+  void map_shouldReturnDebtPositionRegistry_whenEventIsDebtPositionSendEvent() {
+    DebtPositionSendEventDTO dto = new DebtPositionSendEventDTO();
+    dto.setEventType(PaymentEventType.SEND_NOTIFICATION_CREATED);
+    dto.setPayload(new DebtPositionSendNotificationDTO());
+    this.debtPositionRegistryMapperService.map(dto);
+    Mockito.verify(debtPositionSendEventDTO2DebtPositionRegistryMapper, Mockito.times(1)).map(Mockito.any(DebtPositionSendEventDTO.class));
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/InstallmentRegistryMapperServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/mapper/installment/InstallmentRegistryMapperServiceTest.java
@@ -1,0 +1,57 @@
+package it.gov.pagopa.pu.registry.mapper.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.*;
+import it.gov.pagopa.pu.workflowhub.dto.generated.DebtPositionDTO;
+import it.gov.pagopa.pu.workflowhub.dto.generated.PaymentEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class InstallmentRegistryMapperServiceTest {
+
+  private InstallmentRegistryMapperService installmentRegistryMapperService;
+  private DebtPositionEventDTO2InstallmentRegistryMapper debtPositionEventDTO2InstallmentRegistryMapper;
+  private DebtPositionIoEventDTO2InstallmentRegistryMapper debtPositionIoEventDTO2InstallmentRegistryMapper;
+  private DebtPositionSendEventDTO2InstallmentRegistryMapper debtPositionSendEventDTO2InstallmentRegistryMapper;
+
+  @BeforeEach
+  void setUp() {
+    this.debtPositionEventDTO2InstallmentRegistryMapper = Mockito.spy(new DebtPositionEventDTO2InstallmentRegistryMapper());
+    this.debtPositionIoEventDTO2InstallmentRegistryMapper = Mockito.spy(new DebtPositionIoEventDTO2InstallmentRegistryMapper());
+    this.debtPositionSendEventDTO2InstallmentRegistryMapper = Mockito.spy(new DebtPositionSendEventDTO2InstallmentRegistryMapper());
+
+    installmentRegistryMapperService = new InstallmentRegistryMapperService(
+        debtPositionEventDTO2InstallmentRegistryMapper,
+        debtPositionIoEventDTO2InstallmentRegistryMapper,
+        debtPositionSendEventDTO2InstallmentRegistryMapper
+    );
+  }
+
+  @Test
+  void map_shouldReturnInstallmentRegistry_whenEventIsDebtPositionEvent() {
+    DebtPositionEventDTO dto = new DebtPositionEventDTO();
+    dto.setEventType(PaymentEventType.DP_CREATED);
+    dto.setPayload(new DebtPositionDTO());
+    this.installmentRegistryMapperService.map(dto);
+    Mockito.verify(debtPositionEventDTO2InstallmentRegistryMapper, Mockito.times(1)).map(Mockito.any(DebtPositionEventDTO.class));
+  }
+
+  @Test
+  void map_shouldReturnInstallmentRegistry_whenEventIsDebtPositionIoEvent() {
+    DebtPositionIoEventDTO dto = new DebtPositionIoEventDTO();
+    dto.setEventType(PaymentEventType.IO_NOTIFIED);
+    dto.setPayload(new DebtPositionIoNotificationDTO());
+    this.installmentRegistryMapperService.map(dto);
+    Mockito.verify(debtPositionIoEventDTO2InstallmentRegistryMapper, Mockito.times(1)).map(Mockito.any(DebtPositionIoEventDTO.class));
+  }
+
+  @Test
+  void map_shouldReturnInstallmentRegistry_whenEventIsDebtPositionSendEvent() {
+    DebtPositionSendEventDTO dto = new DebtPositionSendEventDTO();
+    dto.setEventType(PaymentEventType.SEND_NOTIFICATION_CREATED);
+    dto.setPayload(new DebtPositionSendNotificationDTO());
+    this.installmentRegistryMapperService.map(dto);
+    Mockito.verify(debtPositionSendEventDTO2InstallmentRegistryMapper, Mockito.times(1)).map(Mockito.any(DebtPositionSendEventDTO.class));
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/service/TimelineServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/service/TimelineServiceTest.java
@@ -1,0 +1,50 @@
+package it.gov.pagopa.pu.registry.service;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.PaymentEventDTO;
+import it.gov.pagopa.pu.registry.mapper.debtposition.DebtPositionRegistryMapperService;
+import it.gov.pagopa.pu.registry.mapper.installment.InstallmentRegistryMapperService;
+import it.gov.pagopa.pu.registry.repository.DebtPositionRegistryRepository;
+import it.gov.pagopa.pu.registry.repository.InstallmentRegistryRepository;
+import it.gov.pagopa.pu.registry.service.debtposition.DebtPositionRegistryService;
+import it.gov.pagopa.pu.registry.service.installment.InstallmentRegistryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TimelineServiceTest {
+
+  private DebtPositionRegistryService debtPositionRegistryService;
+  private InstallmentRegistryService installmentRegistryService;
+  private TimelineService timelineService;
+
+  @BeforeEach
+  void setUp() {
+    this.debtPositionRegistryService = Mockito.spy(new DebtPositionRegistryService(
+      Mockito.mock(DebtPositionRegistryMapperService.class),
+      Mockito.mock(DebtPositionRegistryRepository.class)
+    ));
+    this.installmentRegistryService = Mockito.spy(new InstallmentRegistryService(
+      Mockito.mock(InstallmentRegistryMapperService.class),
+      Mockito.mock(InstallmentRegistryRepository.class)
+    ));
+    this.timelineService = new TimelineService(debtPositionRegistryService, installmentRegistryService);
+  }
+
+  @Test
+  void consumePaymentEvent_whenEventIsValid_shouldCallServices() {
+    PaymentEventDTO<?> event = Mockito.mock(PaymentEventDTO.class);
+
+    timelineService.consumePaymentEvent(event);
+
+    Mockito.verify(debtPositionRegistryService, Mockito.times(1)).consumePaymentEvent(event);
+    Mockito.verify(installmentRegistryService, Mockito.times(1)).consumePaymentEvent(event);
+  }
+
+  @Test
+  void consumePaymentEvent_whenEventIsNull_shouldNotCallServices() {
+    timelineService.consumePaymentEvent(null);
+    Mockito.verify(debtPositionRegistryService, Mockito.never()).consumePaymentEvent(Mockito.any());
+    Mockito.verify(installmentRegistryService, Mockito.never()).consumePaymentEvent(Mockito.any());
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/service/debtposition/DebtPositionRegistryServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/service/debtposition/DebtPositionRegistryServiceTest.java
@@ -1,0 +1,42 @@
+package it.gov.pagopa.pu.registry.service.debtposition;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.PaymentEventDTO;
+import it.gov.pagopa.pu.registry.mapper.debtposition.DebtPositionEventDTO2DebtPositionRegistryMapper;
+import it.gov.pagopa.pu.registry.mapper.debtposition.DebtPositionIoEventDTO2DebtPositionRegistryMapper;
+import it.gov.pagopa.pu.registry.mapper.debtposition.DebtPositionRegistryMapperService;
+import it.gov.pagopa.pu.registry.mapper.debtposition.DebtPositionSendEventDTO2DebtPositionRegistryMapper;
+import it.gov.pagopa.pu.registry.model.DebtPositionRegistry;
+import it.gov.pagopa.pu.registry.repository.DebtPositionRegistryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DebtPositionRegistryServiceTest {
+
+  private DebtPositionRegistryService debtPositionRegistryService;
+  private DebtPositionRegistryRepository debtPositionRegistryRepository;
+  private DebtPositionRegistryMapperService debtPositionRegistryMapperService;
+
+  @BeforeEach
+  void setUp() {
+    this.debtPositionRegistryRepository = Mockito.spy(DebtPositionRegistryRepository.class);
+    this.debtPositionRegistryMapperService = Mockito.spy(new DebtPositionRegistryMapperService(
+      Mockito.mock(DebtPositionEventDTO2DebtPositionRegistryMapper.class),
+      Mockito.mock(DebtPositionIoEventDTO2DebtPositionRegistryMapper.class),
+      Mockito.mock(DebtPositionSendEventDTO2DebtPositionRegistryMapper.class)
+    ));
+    this.debtPositionRegistryService = new DebtPositionRegistryService(
+        debtPositionRegistryMapperService, debtPositionRegistryRepository);
+  }
+
+  @Test
+  void consumePaymentEvent_whenRequestIsValid() {
+    Mockito.when(debtPositionRegistryMapperService.map(Mockito.any(PaymentEventDTO.class))).thenReturn(new DebtPositionRegistry());
+    this.debtPositionRegistryService.consumePaymentEvent(Mockito.mock(PaymentEventDTO.class));
+    Mockito.verify(debtPositionRegistryMapperService, Mockito.times(1))
+        .map(Mockito.any(PaymentEventDTO.class));
+    Mockito.verify(debtPositionRegistryRepository, Mockito.times(1))
+        .save(Mockito.any());
+  }
+
+}

--- a/src/test/java/it/gov/pagopa/pu/registry/service/installment/InstallmentRegistryServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/registry/service/installment/InstallmentRegistryServiceTest.java
@@ -1,0 +1,44 @@
+package it.gov.pagopa.pu.registry.service.installment;
+
+import it.gov.pagopa.pu.registry.event.payments.dto.PaymentEventDTO;
+import it.gov.pagopa.pu.registry.mapper.installment.DebtPositionEventDTO2InstallmentRegistryMapper;
+import it.gov.pagopa.pu.registry.mapper.installment.DebtPositionIoEventDTO2InstallmentRegistryMapper;
+import it.gov.pagopa.pu.registry.mapper.installment.DebtPositionSendEventDTO2InstallmentRegistryMapper;
+import it.gov.pagopa.pu.registry.mapper.installment.InstallmentRegistryMapperService;
+import it.gov.pagopa.pu.registry.model.InstallmentRegistry;
+import it.gov.pagopa.pu.registry.repository.InstallmentRegistryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+class InstallmentRegistryServiceTest {
+
+  private InstallmentRegistryService installmentRegistryService;
+  private InstallmentRegistryRepository installmentRegistryRepository;
+  private InstallmentRegistryMapperService installmentRegistryMapperService;
+
+  @BeforeEach
+  void setUp() {
+    this.installmentRegistryRepository = Mockito.spy(InstallmentRegistryRepository.class);
+    this.installmentRegistryMapperService = Mockito.spy(new InstallmentRegistryMapperService(
+      Mockito.mock(DebtPositionEventDTO2InstallmentRegistryMapper.class),
+      Mockito.mock(DebtPositionIoEventDTO2InstallmentRegistryMapper.class),
+      Mockito.mock(DebtPositionSendEventDTO2InstallmentRegistryMapper.class)
+    ));
+    this.installmentRegistryService = new InstallmentRegistryService(
+      installmentRegistryMapperService, installmentRegistryRepository);
+  }
+
+  @Test
+  void consumePaymentEvent_whenRequestIsValid() {
+    Mockito.when(installmentRegistryMapperService.map(Mockito.any(PaymentEventDTO.class))).thenReturn(List.of(new InstallmentRegistry(), new InstallmentRegistry()));
+    this.installmentRegistryService.consumePaymentEvent(Mockito.mock(PaymentEventDTO.class));
+    Mockito.verify(installmentRegistryMapperService, Mockito.times(1))
+        .map(Mockito.any(PaymentEventDTO.class));
+    Mockito.verify(installmentRegistryRepository, Mockito.times(1))
+        .saveAll(Mockito.any());
+  }
+
+}


### PR DESCRIPTION
#### Description
Implemented the changes required to support the process from the consumption of an event to its mapping and saving to the database. This pull request covers the following tasks:
* P4ADEV-2799
* P4ADEV-2800
* P4ADEV-2801
* P4ADEV-2802
* P4ADEV-2803

#### List of Changes
- Created a `DebtPositionRegistryMapperService` which retrieves as input a payment event and based on the payload it will call the correct mapping service.
- Created a `InstallmentRegistryMapperService` which retrieves as input a payment event and based on the payload it will call the correct mapping service.
- Created a `DebtPositionRegistryService` which retrieves as input a payment event, maps the event to the entity and then saves it in the database.
- Created a `InstallmentRegistryService` which retrieves as input a payment event, maps the event to the entity and then saves it in the database.
- Created a `TimelineService` which retrieves as input a payment event and then proceeds with creating the connected registry entities.
- Adapted the consumer for the payment events to call the `TimelineService` for processing

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [x] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CHORE - Minor Change (fix or feature that don't impact the functionality e.g. Documentation or lint configuration)
